### PR TITLE
Sort fix

### DIFF
--- a/app/assets/javascripts/pages/datasets_resources/datasets_ctrl.js
+++ b/app/assets/javascripts/pages/datasets_resources/datasets_ctrl.js
@@ -92,14 +92,9 @@ function ($scope, $sce) {
         $scope.activeDatasets.splice(0, 0, $scope.activeDatasets.splice(from, 1)[0]);
       }
     } else if ($scope.sortOrder === 0) {
-      $scope.activeDatasets = _($scope.activeDatasets).chain()
-      .sortBy(function(dataset) {
-        return dataset.title;
-      })
-      .reverse()
-      .sortBy(function(dataset) {
+      $scope.activeDatasets = _.sortBy($scope.activeDatasets, function(dataset) {
         return dataset.publication_date_year_epoch;
-      }).reverse().value();
+      }).reverse();
     } else if ($scope.sortOrder === 1) {
       $scope.activeDatasets = _.sortBy($scope.activeDatasets, "title");
     }

--- a/app/assets/javascripts/pages/datasets_resources/datasets_ctrl.js
+++ b/app/assets/javascripts/pages/datasets_resources/datasets_ctrl.js
@@ -92,9 +92,14 @@ function ($scope, $sce) {
         $scope.activeDatasets.splice(0, 0, $scope.activeDatasets.splice(from, 1)[0]);
       }
     } else if ($scope.sortOrder === 0) {
-      $scope.activeDatasets = _.sortBy($scope.activeDatasets, function(dataset) {
+      $scope.activeDatasets = _($scope.activeDatasets).chain()
+      .sortBy(function(dataset) {
+        return dataset.title;
+      })
+      .reverse()
+      .sortBy(function(dataset) {
         return dataset.publication_date_year_epoch;
-      }).reverse();
+      }).reverse().value();
     } else if ($scope.sortOrder === 1) {
       $scope.activeDatasets = _.sortBy($scope.activeDatasets, "title");
     }

--- a/app/assets/javascripts/pages/datasets_resources/datasets_ctrl.js
+++ b/app/assets/javascripts/pages/datasets_resources/datasets_ctrl.js
@@ -83,7 +83,6 @@ function ($scope, $sce) {
     );
     updateActiveContentTypesFromNames(activeContentTypeNames);
     $scope.sortDatesets();
-    $scope.setHiddenDatasets();
   }
 
   $scope.sortDatesets = function () {
@@ -99,6 +98,7 @@ function ($scope, $sce) {
     } else if ($scope.sortOrder === 1) {
       $scope.activeDatasets = _.sortBy($scope.activeDatasets, "title");
     }
+    $scope.setHiddenDatasets();
   }
 
   $scope.sortDatesetsToBeDisplayed = function () {
@@ -133,7 +133,6 @@ function ($scope, $sce) {
     for (var i=0; i < 10 && $scope.hiddenDatasets.length > 0; i++) {
       var datasetItem = $scope.hiddenDatasets.shift();
       $scope.datasetsToBeDisplayed.push(datasetItem);
-      $scope.sortDatesetsToBeDisplayed();
     }
   }
 

--- a/app/assets/javascripts/pages/datasets_resources/datasets_ctrl.js
+++ b/app/assets/javascripts/pages/datasets_resources/datasets_ctrl.js
@@ -101,17 +101,6 @@ function ($scope, $sce) {
     $scope.setHiddenDatasets();
   }
 
-  $scope.sortDatesetsToBeDisplayed = function () {
-    if ($scope.sortOrder === 0) {
-      $scope.datasetsToBeDisplayed = _.sortBy(
-        $scope.datasetsToBeDisplayed, function(dataset) {
-          return dataset.publication_date_year_epoch;
-      }).reverse();
-    } else if ($scope.sortOrder === 1) {
-      $scope.datasetsToBeDisplayed = _.sortBy($scope.datasetsToBeDisplayed, "title");
-    }
-  }
-
   var initDatasets = function () {
     _.each($scope.datasets, function (dataset) {
       if (dataset.publication_date_year !== '') {

--- a/app/assets/javascripts/pages/datasets_resources/datasets_ctrl.js
+++ b/app/assets/javascripts/pages/datasets_resources/datasets_ctrl.js
@@ -117,7 +117,7 @@ function ($scope, $sce) {
       if (dataset.publication_date_year !== '') {
         dataset.publication_date_year_epoch = Date.parse(dataset.publication_date_year);
       } else if (dataset.publication_date !== '') {
-        dataset.publication_date_year_epoch = Date.parse(new Date(dataset.publication_date).getFullYear());
+        dataset.publication_date_year_epoch = Date.parse(new Date(dataset.publication_date));
       } else {
         dataset.publication_date_year_epoch = 1;
       }

--- a/app/views/datasets/_list.html.haml
+++ b/app/views/datasets/_list.html.haml
@@ -29,7 +29,7 @@
       %li.content_type{"ng-show" => "contentType.count > 0", "ng-class" => "{active: contentType.selected && contentType.count > 0}", "ng-click" => "toggleContentType()", "ng-repeat" => "contentType in contentTypes"}
         %span.badge {{ contentType.count }}
         %p {{ contentType.plural }}
-    %select#sorting{"ng-change" => "sortDatesetsToBeDisplayed()", "ng-model" => "sortOrder", "ng-options" => "order.value as order.name for order in sortOrders"}
+    %select#sorting{"ng-change" => "sortDatesets()", "ng-model" => "sortOrder", "ng-options" => "order.value as order.name for order in sortOrders"}
     .info-message
       %h1 Policies
       %p UNEP-WCMC does not assert any intellectual property rights in the data made available to it by data providers.


### PR DESCRIPTION
This pull request is about fixing the sorting of resources/datasets.
Now the datasets are sorted all at once instead of sorting just the displayed ones.
There is just an issue about the most recent case: if there are more datasets with the same date, the first sorting by most recent (which is the default one) is different from the sorting that will happen after sorting alphabetically. This is probably because the javascript sorting takes in consideration just the position of the elements at the current moment.
To make this more consistent, we could set the alphabetical sorting as the default one, or sort alphabetically "behind the scenes" first (in case is preferable to keep the most recent sorting as the default one)