### PR TITLE
Fix bug when spaces are present in job application code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Fixed the consistency of the filenames across downloads.
 * Reduced the length of the zip filenames.
 * Bug fix for a bug which appears on staging within `application_generate_zip`.
+* Bug fix for a bug which appears on staging when job application codes contain a space.
 
 
 ### 0.1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,6 @@
 * Fixed the consistency of the filenames across downloads.
 * Reduced the length of the zip filenames.
 * Bug fix for a bug which appears on staging within `application_generate_zip`.
-* Bug fix for a bug which appears on staging when job application codes contain a space.
 
 
 ### 0.1.0

--- a/app/controllers/job_applications_controller.rb
+++ b/app/controllers/job_applications_controller.rb
@@ -12,7 +12,7 @@ class JobApplicationsController < ApplicationController
   def download_all_applications_zip
     form = Form.find(params[:id])
     path = Rails.root.join('private', 'zip', 'all_job_applications')
-    vacancy_label = form.vacancy.label.scan(/\((.*)\)/).first.first
+    vacancy_label = form.vacancy.label.scan(/\((.*)\)/).first.first.parameterize.underscore
     filename = "#{vacancy_label}.zip"
     zip = Download::GenerateZip.new(path, filename)
 
@@ -30,7 +30,7 @@ class JobApplicationsController < ApplicationController
   def download_application_zip
     submission = Submission.find_by(slug: params[:id])
     path = Rails.root.join('private', 'zip', 'job_applications')
-    vacancy_label = submission.form.vacancy.label.scan(/\((.*)\)/).first.first
+    vacancy_label = submission.form.vacancy.label.scan(/\((.*)\)/).first.first.parameterize.underscore
     filename = "#{vacancy_label}-#{submission.name.parameterize.underscore}.zip"
     zip = Download::GenerateZip.new(path, filename)
 

--- a/app/controllers/job_applications_controller.rb
+++ b/app/controllers/job_applications_controller.rb
@@ -16,7 +16,7 @@ class JobApplicationsController < ApplicationController
     filename = "#{vacancy_label}.zip"
     zip = Download::GenerateZip.new(path, filename)
 
-    unless zip.zip_exists?
+    if zip.zip_needs_regenerating? form.submissions.pluck(:updated_at).sort.last
       zip.all_applications_generate_zip(form.id)
     end
 
@@ -34,7 +34,7 @@ class JobApplicationsController < ApplicationController
     filename = "#{vacancy_label}-#{submission.name.parameterize.underscore}.zip"
     zip = Download::GenerateZip.new(path, filename)
 
-    unless zip.zip_exists?
+    if zip.zip_needs_regenerating? submission.updated_at
       zip.application_generate_zip(submission.id)
     end
 

--- a/app/controllers/job_applications_controller.rb
+++ b/app/controllers/job_applications_controller.rb
@@ -12,7 +12,7 @@ class JobApplicationsController < ApplicationController
   def download_all_applications_zip
     form = Form.find(params[:id])
     path = Rails.root.join('private', 'zip', 'all_job_applications')
-    vacancy_label = form.vacancy.label.scan(/\((.*)\)/).first.first.parameterize.underscore
+    vacancy_label = form.vacancy.formatted_label
     filename = "#{vacancy_label}.zip"
     zip = Download::GenerateZip.new(path, filename)
 
@@ -30,7 +30,7 @@ class JobApplicationsController < ApplicationController
   def download_application_zip
     submission = Submission.find_by(slug: params[:id])
     path = Rails.root.join('private', 'zip', 'job_applications')
-    vacancy_label = submission.form.vacancy.label.scan(/\((.*)\)/).first.first.parameterize.underscore
+    vacancy_label = submission.form.vacancy.formatted_label
     filename = "#{vacancy_label}-#{submission.name.parameterize.underscore}.zip"
     zip = Download::GenerateZip.new(path, filename)
 

--- a/app/controllers/job_applications_controller.rb
+++ b/app/controllers/job_applications_controller.rb
@@ -13,10 +13,11 @@ class JobApplicationsController < ApplicationController
     form = Form.find(params[:id])
     path = Rails.root.join('private', 'zip', 'all_job_applications')
     vacancy_label = form.vacancy.formatted_label
+    last_uploaded_submission = form.submissions.order(updated_at: :asc).last
     filename = "#{vacancy_label}.zip"
     zip = Download::GenerateZip.new(path, filename)
 
-    if zip.zip_needs_regenerating? form.submissions.pluck(:updated_at).sort.last
+    if zip.zip_needs_regenerating? last_uploaded_submission.updated_at
       zip.all_applications_generate_zip(form.id)
     end
 

--- a/app/models/form.rb
+++ b/app/models/form.rb
@@ -5,7 +5,7 @@
 # and FileFieldSubmissions is built, with the shape of a corresponding Form.
 
 class Form < ActiveRecord::Base
-  belongs_to :vacancy, class_name: "Comfy::Cms::Page"
+  belongs_to :vacancy
   has_many :submissions, dependent: :destroy
   has_many :fields, dependent: :destroy, inverse_of: :form
   has_many :attachments, dependent: :destroy, inverse_of: :form

--- a/app/models/vacancy.rb
+++ b/app/models/vacancy.rb
@@ -1,5 +1,7 @@
 class Vacancy < Comfy::Cms::Page
 
+  has_many :forms
+
   def formatted_label
     job_code = label.scan(/\((.*)\)/)
     return "unknown_job_code" unless job_code.present?

--- a/app/models/vacancy.rb
+++ b/app/models/vacancy.rb
@@ -1,0 +1,9 @@
+class Vacancy < Comfy::Cms::Page
+
+  def formatted_label
+    job_code = label.scan(/\((.*)\)/)
+    return "unknown_job_code" unless job_code.present?
+    job_code.first.first.parameterize.underscore
+  end
+
+end

--- a/lib/download/generate_zip.rb
+++ b/lib/download/generate_zip.rb
@@ -64,6 +64,14 @@ class Download::GenerateZip
     system("ls #{@path}/#{@zip_path}")
   end
 
+  def zip_needs_regenerating? last_uploaded_application_time
+    zip_file_exists = system("ls #{@path}/#{@zip_path}")
+    return true if zip_file_exists == false
+
+    zip_file_modification_time = File.mtime(@path + @zip_path)
+    zip_file_modification_time < last_uploaded_application_time
+  end
+
   def delete_zip
     system("rm -rf #{@zip_path}", chdir: @path)
   end

--- a/lib/download/generate_zip.rb
+++ b/lib/download/generate_zip.rb
@@ -65,10 +65,9 @@ class Download::GenerateZip
   end
 
   def zip_needs_regenerating? last_uploaded_application_time
-    zip_file_exists = system("ls #{@path}/#{@zip_path}")
-    return true if zip_file_exists == false
+    return true unless File.exists?("#{@path}/#{@zip_path}")
 
-    zip_file_modification_time = File.mtime(@path + @zip_path)
+    zip_file_modification_time = File.mtime("#{@path}/#{@zip_path}")
     zip_file_modification_time < last_uploaded_application_time
   end
 

--- a/lib/download/generate_zip.rb
+++ b/lib/download/generate_zip.rb
@@ -13,7 +13,7 @@ class Download::GenerateZip
     submission = Submission.find_by(id: submission_id)
     return unless submission.attachments_valid?
     candidate_path = "#{submission.name}".parameterize.underscore
-    vacancy_label = submission.form.vacancy.label.scan(/\((.*)\)/).first.first
+    vacancy_label = submission.form.vacancy.label.scan(/\((.*)\)/).first.first.parameterize.underscore
     zipped_files_path = "form-#{vacancy_label}-#{candidate_path}".parameterize.underscore
     document_path = "#{zipped_files_path}/#{vacancy_label}_#{candidate_path}"
     cv_extension = File.extname(submission.cv_file_name)
@@ -40,7 +40,7 @@ class Download::GenerateZip
       next unless submission.attachments_valid?
       candidate_path = "#{submission.name}".parameterize.underscore
       all_submissions_path = "all_submissions"
-      vacancy_label = form.vacancy.label.scan(/\((.*)\)/).first.first
+      vacancy_label = form.vacancy.label.scan(/\((.*)\)/).first.first.parameterize.underscore
       documents_path = "#{zipped_files_path}/#{candidate_path}/#{vacancy_label}_#{candidate_path}"
       cv_extension = File.extname(submission.cv_file_name)
       application_form_extension = File.extname(submission.application_form_file_name)

--- a/lib/download/generate_zip.rb
+++ b/lib/download/generate_zip.rb
@@ -13,7 +13,7 @@ class Download::GenerateZip
     submission = Submission.find_by(id: submission_id)
     return unless submission.attachments_valid?
     candidate_path = "#{submission.name}".parameterize.underscore
-    vacancy_label = submission.form.vacancy.label.scan(/\((.*)\)/).first.first.parameterize.underscore
+    vacancy_label = submission.form.vacancy.formatted_label
     zipped_files_path = "form-#{vacancy_label}-#{candidate_path}".parameterize.underscore
     document_path = "#{zipped_files_path}/#{vacancy_label}_#{candidate_path}"
     cv_extension = File.extname(submission.cv_file_name)
@@ -40,7 +40,7 @@ class Download::GenerateZip
       next unless submission.attachments_valid?
       candidate_path = "#{submission.name}".parameterize.underscore
       all_submissions_path = "all_submissions"
-      vacancy_label = form.vacancy.label.scan(/\((.*)\)/).first.first.parameterize.underscore
+      vacancy_label = form.vacancy.formatted_label
       documents_path = "#{zipped_files_path}/#{candidate_path}/#{vacancy_label}_#{candidate_path}"
       cv_extension = File.extname(submission.cv_file_name)
       application_form_extension = File.extname(submission.application_form_file_name)


### PR DESCRIPTION
This is the initial work towards fixing a bug which occurs when a job application code contains a space. I reproduced this bug by using the staging database locally.