### PR TITLE
Fix bug empty zip file for all job applications download

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Fixed the consistency of the filenames across downloads.
 * Reduced the length of the zip filenames.
 * Bug fix for a bug which appears on staging within `application_generate_zip`.
+* Bug fix to only generate a zip for all job applications if any of the submissions have valid attachments.
 
 
 ### 0.1.0

--- a/app/controllers/submissions_controller.rb
+++ b/app/controllers/submissions_controller.rb
@@ -38,6 +38,14 @@ class SubmissionsController < ApplicationController
   def destroy
     @submission = @form.submissions.find_by_slug!(params[:id])
     @submission.destroy
+
+    path = Rails.root.join('private', 'zip', 'all_job_applications')
+    vacancy_label = @form.vacancy.formatted_label
+    filename = "#{vacancy_label}.zip"
+    zip = Download::GenerateZip.new(path, filename)
+    zip.delete_zip
+    zip.all_applications_generate_zip(@form.id)
+
     redirect_to job_application_path(@form), notice: 'Job application was successfully destroyed.'
   end
 

--- a/lib/download/generate_zip.rb
+++ b/lib/download/generate_zip.rb
@@ -33,7 +33,7 @@ class Download::GenerateZip
 
   def all_applications_generate_zip form_id
     form = Form.find_by(id: form_id)
-    return unless all_documents_valid? form
+    return unless any_submissions_with_documents_valid? form
     zipped_files_path = "form-#{form.vacancy.label}".parameterize.underscore
     system("mkdir #{zipped_files_path}", chdir: @path)
 
@@ -72,7 +72,7 @@ class Download::GenerateZip
     zip_file_modification_time < last_uploaded_application_time
   end
 
-  def all_documents_valid? form
+  def any_submissions_with_documents_valid? form
     form.submissions.each do |submission|
       return true if submission.attachments_valid?
     end

--- a/lib/download/generate_zip.rb
+++ b/lib/download/generate_zip.rb
@@ -33,6 +33,7 @@ class Download::GenerateZip
 
   def all_applications_generate_zip form_id
     form = Form.find_by(id: form_id)
+    return unless all_documents_valid? form
     zipped_files_path = "form-#{form.vacancy.label}".parameterize.underscore
     system("mkdir #{zipped_files_path}", chdir: @path)
 
@@ -61,7 +62,7 @@ class Download::GenerateZip
   end
 
   def zip_exists?
-    system("ls #{@path}/#{@zip_path}")
+    File.exists?("#{@path}/#{@zip_path}")
   end
 
   def zip_needs_regenerating? last_uploaded_application_time
@@ -69,6 +70,14 @@ class Download::GenerateZip
 
     zip_file_modification_time = File.mtime("#{@path}/#{@zip_path}")
     zip_file_modification_time < last_uploaded_application_time
+  end
+
+  def all_documents_valid? form
+    status = []
+    form.submissions.each do |submission|
+      status << submission.attachments_valid?
+    end
+    status.include?(true)
   end
 
   def delete_zip

--- a/lib/download/generate_zip.rb
+++ b/lib/download/generate_zip.rb
@@ -73,11 +73,10 @@ class Download::GenerateZip
   end
 
   def all_documents_valid? form
-    status = []
     form.submissions.each do |submission|
-      status << submission.attachments_valid?
+      return true if submission.attachments_valid?
     end
-    status.include?(true)
+    return false
   end
 
   def delete_zip

--- a/lib/tasks/remove_zip_cache.rake
+++ b/lib/tasks/remove_zip_cache.rake
@@ -5,11 +5,11 @@ namespace :remove do
 
     logger.info "Removing cached zip files for all_job_applications"
     path = Rails.root.join('private', 'zip', 'all_job_applications')
-    system("rm -rf *.zip", chdir: path)
+    system("rm *.zip", chdir: path)
 
     logger.info "Removing cached zip files for job_applications"
     path = Rails.root.join('private', 'zip', 'job_applications')
-    system("rm -rf *.zip", chdir: path)
+    system("rm *.zip", chdir: path)
   end
 
   def logger

--- a/lib/tasks/remove_zip_cache.rake
+++ b/lib/tasks/remove_zip_cache.rake
@@ -1,0 +1,18 @@
+namespace :remove do
+  desc "remove cached zip files"
+  task :zip_cache => [:environment] do |t, args|
+    logger.info "Removing cached zip files..."
+
+    logger.info "Removing cached zip files for all_job_applications"
+    path = Rails.root.join('private', 'zip', 'all_job_applications')
+    system("rm -rf *.zip", chdir: path)
+
+    logger.info "Removing cached zip files for job_applications"
+    path = Rails.root.join('private', 'zip', 'job_applications')
+    system("rm -rf *.zip", chdir: path)
+  end
+
+  def logger
+    @logger ||= Logger.new("#{Rails.root}/log/remove_zip_cache.log")
+  end
+end


### PR DESCRIPTION
Here is the initial work to solve the bug where an empty zip file is generated for all job application zip file downloads when the necessary attachments are missing. This will produce an error instead of creating an empty zip file.