### PR TITLE
Prevent the regeneration of the zip for all job applications when submission is deleted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Reduced the length of the zip filenames.
 * Bug fix for a bug which appears on staging within `application_generate_zip`.
 * Bug fix to only generate a zip for all job applications if any of the submissions have valid attachments.
+* Removed the regeneration of the zip for job applications when a submission is deleted.
 
 
 ### 0.1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,6 @@
 * Reduced the length of the zip filenames.
 * Bug fix for a bug which appears on staging within `application_generate_zip`.
 * Bug fix to only generate a zip for all job applications if any of the submissions have valid attachments.
-* Removed the regeneration of the zip for job applications when a submission is deleted.
 
 
 ### 0.1.0

--- a/app/controllers/submissions_controller.rb
+++ b/app/controllers/submissions_controller.rb
@@ -44,7 +44,6 @@ class SubmissionsController < ApplicationController
     filename = "#{vacancy_label}.zip"
     zip = Download::GenerateZip.new(path, filename)
     zip.delete_zip
-    zip.all_applications_generate_zip(@form.id)
 
     redirect_to job_application_path(@form), notice: 'Job application was successfully destroyed.'
   end


### PR DESCRIPTION
This is the initial work towards preventing the regeneration of the zip for all job applications whenever a submission is deleted. As recommended by @spencerldixon 