### PR TITLE
Add publication based on date

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+### 0.4.0
+
+**Add published_date for future published news pages:**
+
+* Added ability to publish articles in the future
+
+
 ### 0.3.0
 
 **Add Proteus technical briefing note filter:**

--- a/app/helpers/page_resources_helper.rb
+++ b/app/helpers/page_resources_helper.rb
@@ -20,7 +20,7 @@ module PageResourcesHelper
   def employees_page
     @employees_page ||= Comfy::Cms::Site.find_by_identifier('employees').pages.root
   end
-  
+
   def expertise_page
     @expertise_page ||= Comfy::Cms::Site.find_by_identifier('expertise').pages.root
   end

--- a/config/initializers/overrides.rb
+++ b/config/initializers/overrides.rb
@@ -1,3 +1,16 @@
 Comfy::Cms::Page.class_eval do
+  before_save :extract_published_date
+
   scope :published, -> { unscoped.where('published_date <= ? AND is_published = true', Date.today) }
+
+  private
+
+  def extract_published_date
+    self.blocks_attributes.map do |attr|
+      if attr[:identifier] == "time"
+        self.published_date = attr[:content]
+        return
+      end
+    end
+  end
 end

--- a/config/initializers/overrides.rb
+++ b/config/initializers/overrides.rb
@@ -1,7 +1,7 @@
 Comfy::Cms::Page.class_eval do
   before_save :extract_published_date
 
-  scope :published, -> { unscoped.where('published_date <= ? AND is_published = true', Date.today) }
+  scope :published, -> { where('published_date <= ? AND is_published = true', Date.today) }
 
   private
 

--- a/config/initializers/overrides.rb
+++ b/config/initializers/overrides.rb
@@ -1,3 +1,3 @@
 Comfy::Cms::Page.class_eval do
-  scope :published, -> { unscoped.where('published_date < ? AND is_published = true', Date.today) }
+  scope :published, -> { unscoped.where('published_date <= ? AND is_published = true', Date.today) }
 end

--- a/config/initializers/overrides.rb
+++ b/config/initializers/overrides.rb
@@ -1,0 +1,3 @@
+Comfy::Cms::Page.class_eval do
+  scope :published, -> { unscoped.where('published_date < ? AND is_published = true', Date.today) }
+end

--- a/db/migrate/20180718082125_add_published_date_to_comfy_cms_page.rb
+++ b/db/migrate/20180718082125_add_published_date_to_comfy_cms_page.rb
@@ -1,0 +1,5 @@
+class AddPublishedDateToComfyCmsPage < ActiveRecord::Migration
+  def change
+    add_column :comfy_cms_pages, :published_date, :datetime, default: Date.today
+  end
+end

--- a/db/migrate/20180718082125_add_published_date_to_comfy_cms_page.rb
+++ b/db/migrate/20180718082125_add_published_date_to_comfy_cms_page.rb
@@ -1,5 +1,10 @@
 class AddPublishedDateToComfyCmsPage < ActiveRecord::Migration
   def change
-    add_column :comfy_cms_pages, :published_date, :datetime, default: Date.today
+    add_column :comfy_cms_pages, :published_date, :datetime
+
+    Comfy::Cms::Page.find_each do |page|
+      page.published_date = page.created_at
+      page.save!
+    end
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -90,22 +90,22 @@ ActiveRecord::Schema.define(version: 20180718082125) do
   add_index "comfy_cms_layouts", ["site_id", "identifier"], name: "index_comfy_cms_layouts_on_site_id_and_identifier", unique: true, using: :btree
 
   create_table "comfy_cms_pages", force: :cascade do |t|
-    t.integer  "site_id",                                                    null: false
+    t.integer  "site_id",                                    null: false
     t.integer  "layout_id"
     t.integer  "parent_id"
     t.integer  "target_page_id"
-    t.string   "label",          limit: 255,                                 null: false
+    t.string   "label",          limit: 255,                 null: false
     t.string   "slug",           limit: 255
-    t.string   "full_path",      limit: 255,                                 null: false
+    t.string   "full_path",      limit: 255,                 null: false
     t.text     "content_cache"
-    t.integer  "position",                   default: 0,                     null: false
-    t.integer  "children_count",             default: 0,                     null: false
-    t.boolean  "is_published",               default: true,                  null: false
-    t.boolean  "is_shared",                  default: false,                 null: false
+    t.integer  "position",                   default: 0,     null: false
+    t.integer  "children_count",             default: 0,     null: false
+    t.boolean  "is_published",               default: true,  null: false
+    t.boolean  "is_shared",                  default: false, null: false
     t.datetime "created_at"
     t.datetime "updated_at"
     t.boolean  "is_top_project",             default: false
-    t.datetime "published_date",             default: '2018-07-18 00:00:00'
+    t.datetime "published_date"
   end
 
   add_index "comfy_cms_pages", ["parent_id", "position"], name: "index_comfy_cms_pages_on_parent_id_and_position", using: :btree

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160411112159) do
+ActiveRecord::Schema.define(version: 20180718082125) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -90,21 +90,22 @@ ActiveRecord::Schema.define(version: 20160411112159) do
   add_index "comfy_cms_layouts", ["site_id", "identifier"], name: "index_comfy_cms_layouts_on_site_id_and_identifier", unique: true, using: :btree
 
   create_table "comfy_cms_pages", force: :cascade do |t|
-    t.integer  "site_id",                                    null: false
+    t.integer  "site_id",                                                    null: false
     t.integer  "layout_id"
     t.integer  "parent_id"
     t.integer  "target_page_id"
-    t.string   "label",          limit: 255,                 null: false
+    t.string   "label",          limit: 255,                                 null: false
     t.string   "slug",           limit: 255
-    t.string   "full_path",      limit: 255,                 null: false
+    t.string   "full_path",      limit: 255,                                 null: false
     t.text     "content_cache"
-    t.integer  "position",                   default: 0,     null: false
-    t.integer  "children_count",             default: 0,     null: false
-    t.boolean  "is_published",               default: true,  null: false
-    t.boolean  "is_shared",                  default: false, null: false
+    t.integer  "position",                   default: 0,                     null: false
+    t.integer  "children_count",             default: 0,                     null: false
+    t.boolean  "is_published",               default: true,                  null: false
+    t.boolean  "is_shared",                  default: false,                 null: false
     t.datetime "created_at"
     t.datetime "updated_at"
     t.boolean  "is_top_project",             default: false
+    t.datetime "published_date",             default: '2018-07-18 00:00:00'
   end
 
   add_index "comfy_cms_pages", ["parent_id", "position"], name: "index_comfy_cms_pages_on_parent_id_and_position", using: :btree


### PR DESCRIPTION
Initial support for future `published_date`. Using the existing `Time` field on the news articles edit page. This `Time` is extracted and put into the `published_date` field in the table for `Comfy::Cms::Page` before a page is saved. 

This will display articles which have a date of today or before. News articles in the future will not be visible unless the date is the same or beyond that date.