### PR TITLE
Fix for og:url content url using relative path of url instead of full path of cms page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 0.3.3
+
+* Fix up og:url content url using relative path of url
+
 ### 0.3.2
 
 * Fix up styling on the /wcmc website

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -18,7 +18,7 @@
       %meta{ :name => "twitter:title", :content => "#{@cms_page.label.titleize} - UNEP-WCMC" }
       %meta{ :itemprop => "name", :content => "#{@cms_page.label.titleize} - UNEP-WCMC" }
       %meta{ :property => "og:title", :content => "#{@cms_page.label.titleize} - UNEP-WCMC" }
-      %meta{ :property => "og:url", :content => "https://www.unep-wcmc.org#{@cms_page.full_path}" }
+      %meta{ :property => "og:url", :content => "https://www.unep-wcmc.org#{@cms_page.url(relative: true)}" }
       %meta{ :property => "og:site_name", :content => "UNEP-WCMC's official website - #{@cms_page.label.titleize}" }
     %title
       - if content_for(:title)


### PR DESCRIPTION
This is a small fix for the `og:url` content url using relative path of url rather than the `full_path` which was currently in place for the `cms_page`.