### PR TITLE
Updated Twitter share link text

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -40,4 +40,63 @@ module ApplicationHelper
 
     link_to(text, path, opts)
   end
+
+  def get_current_page_full_url
+    return request.base_url + request.fullpath
+  end
+
+  def email_share_subject
+    email_subject = ''
+
+    if cms_block_content(:email_share_subject) != ''
+      email_subject = cms_block_content(:email_share_subject)
+    elsif cms_block_content(:project_name, @cms_page) != ''
+      email_subject = cms_block_content(:project_name, @cms_page)
+    elsif cms_block_content(:news_header, @cms_page) != ''
+      email_subject = cms_block_content(:news_header, @cms_page)
+    elsif cms_block_content(:position_title, @cms_page) != ''
+      email_subject = cms_block_content(:position_title, @cms_page) + ' at UNEP-WCMC'
+    else
+      email_subject = 'Visit the UNEP-WCMC website'
+    end
+
+    return ERB::Util.url_encode(email_subject)
+  end
+
+  def email_share_body
+    email_body = ''
+
+    if cms_block_content(:email_share_content) != ''
+      email_body = cms_block_content(:email_share_content)
+    elsif cms_block_content(:project_name, @cms_page) != ''
+      email_body = cms_block_content(:project_name, @cms_page) + ': ' + get_current_page_full_url
+    elsif cms_block_content(:news_header, @cms_page) != ''
+      email_body = cms_block_content(:news_header, @cms_page) + ': ' + get_current_page_full_url
+    elsif cms_block_content(:position_title, @cms_page) != ''
+      email_body = cms_block_content(:position_title, @cms_page) + ' at UNEP-WCMC: ' + get_current_page_full_url
+    else
+      email_body = 'Visit the UNEP-WCMC website: ' + get_current_page_full_url
+    end
+
+    return ERB::Util.url_encode(email_body)
+  end
+
+  def twitter_share_text
+    share_text = ''
+    share_text_end = ' | Read more on the @unepwcmc website: ' + get_current_page_full_url
+
+    if cms_block_content(:email_share_subject) != ''
+      share_text = cms_block_content(:email_share_subject) + share_text_end
+    elsif cms_block_content(:project_name, @cms_page) != ''
+      share_text = cms_block_content(:project_name, @cms_page) + share_text_end
+    elsif cms_block_content(:news_header, @cms_page) != ''
+      share_text = cms_block_content(:news_header, @cms_page) + share_text_end
+    elsif cms_block_content(:position_title, @cms_page) != ''
+      share_text = cms_block_content(:position_title, @cms_page) + share_text_end
+    else
+      share_text = 'Visit the @unepwcmc website | ' + get_current_page_full_url
+    end
+
+    return ERB::Util.url_encode(share_text)
+  end
 end

--- a/app/views/shared/_share_links.html.haml
+++ b/app/views/shared/_share_links.html.haml
@@ -1,6 +1,6 @@
 %a{ :href => "mailto:?subject=#{cms_block_content(:email_share_subject)}&body=#{cms_block_content(:email_share_content)}"}
   %i.icon-envelope
   Email
-%a{ :href => "https://twitter.com/share?text=#{cms_block_content(:twitter_share_text)}", :target => "_blank" }
+%a{ :href => "https://twitter.com/intent/tweet?text=#{cms_block_content(:twitter_share_text)}%20%7C%20Read more%20on%20the%20@unepwcmc%20website%20#{request.base_url + request.fullpath}", :target => "_blank" }
   %i.icon-twitter
   Twitter

--- a/app/views/shared/_share_links.html.haml
+++ b/app/views/shared/_share_links.html.haml
@@ -1,6 +1,6 @@
-%a{ :href => "mailto:?subject=#{cms_block_content(:email_share_subject)}&body=#{cms_block_content(:email_share_content)}"}
+%a{ :href => "mailto:?subject=#{email_share_subject}&body=#{email_share_body}"}
   %i.icon-envelope
   Email
-%a{ :href => "https://twitter.com/intent/tweet?text=#{cms_block_content(:twitter_share_text)}%20%7C%20Read more%20on%20the%20@unepwcmc%20website%20#{request.base_url + request.fullpath}", :target => "_blank" }
+%a{ :href => "https://twitter.com/intent/tweet?text=#{twitter_share_text}", :target => "_blank" }
   %i.icon-twitter
   Twitter


### PR DESCRIPTION
Updated Twitter share tweet text to say: "#{cms_block_content(:twitter_share_text)}%20%7C%20Read more%20on%20the%20@unepwcmc%20website%20#{request.base_url + request.fullpath}"

e.g. "Oil For Development | Read more on the @unepwcmc website https://www.unep-wcmc.org/featured-projects/oil-for-development"