### PR TITLE
Rewrote methods and script to use confirm_by_token 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 0.3.3
+
+* Fix admin error on news tab
+
 ### 0.3.2
 
 * Fix up styling on the /wcmc website

--- a/app/controllers/confirmations_controller.rb
+++ b/app/controllers/confirmations_controller.rb
@@ -18,7 +18,16 @@ class ConfirmationsController < Devise::ConfirmationsController
   private
 
   def set_user
+    if !params[:confirmation_token] || params[:confirmation_token].empty?
+      flash[:notice] = 'Missing confirmation token. Please contact your administrator to resend confirmation instructions.'
+      redirect_to '/'
+    end
     @user = User.confirm_by_token(params[:confirmation_token])
+    # If confirm_by_token cannot find user
+    if @user.id.nil?
+      flash[:notice] = 'Invalid confirmation token. Please contact your administrator to resend confirmation instructions.'
+      redirect_to '/'
+    end
   end
 
   def password_params

--- a/app/controllers/confirmations_controller.rb
+++ b/app/controllers/confirmations_controller.rb
@@ -18,10 +18,7 @@ class ConfirmationsController < Devise::ConfirmationsController
   private
 
   def set_user
-    # token = Devise.token_generator.digest(User, :confirmation_token, params[:confirmation_token])
-    # @user = User.find_by_confirmation_token!(token)
-    token = params[:confirmation_token]
-    @user = User.confirm_by_token(token)
+    @user = User.confirm_by_token(params[:confirmation_token])
   end
 
   def password_params

--- a/app/controllers/confirmations_controller.rb
+++ b/app/controllers/confirmations_controller.rb
@@ -36,7 +36,9 @@ class ConfirmationsController < Devise::ConfirmationsController
     if @user
       if !@user.confirmed_at.nil?
         flash[:notice] = "Email address already confirmed, please sign in."
-        redirect_to comfy_admin_cms_path
+        sign_out current_user
+        # To stop users using multiple confirmation links if signed in with one account already.
+        redirect_to new_user_session_path
       elsif @user.id.nil?
         flash[:notice] = 'Invalid confirmation token. Please contact your administrator to resend confirmation instructions.'
         redirect_to '/'

--- a/app/controllers/confirmations_controller.rb
+++ b/app/controllers/confirmations_controller.rb
@@ -44,6 +44,5 @@ class ConfirmationsController < Devise::ConfirmationsController
         redirect_to new_user_session_path
       end
     end
-    # raise
   end
 end

--- a/app/controllers/confirmations_controller.rb
+++ b/app/controllers/confirmations_controller.rb
@@ -29,13 +29,13 @@ class ConfirmationsController < Devise::ConfirmationsController
       return
     else
       if @user != current_user && user_signed_in?
-        sign_out current_user
         # To stop users using multiple confirmation links if signed in with one account already.
         if @user.confirmed_at.nil?
-          flash[:error] = "Please confirm your new account."
+          sign_out current_user
+          flash[:notice] = "Please confirm your new account."
         else
-          flash[:error] = "Account already confirmed. Please contact your administrator to resend confirmation instructions."
-          redirect_to '/'
+          flash[:error] = "Account already confirmed. Please contact your administrator for a new confirmation email."
+          redirect_to comfy_admin_cms_path
           return
         end
       end

--- a/app/controllers/confirmations_controller.rb
+++ b/app/controllers/confirmations_controller.rb
@@ -18,31 +18,32 @@ class ConfirmationsController < Devise::ConfirmationsController
   private
 
   def set_user
-    if params[:confirmation_token].blank?
-      flash[:notice] = 'Missing confirmation token. Please contact your administrator to resend confirmation instructions.'
-      redirect_to '/'
-      return
-    end
+    pre_checks
     @user = User.confirm_by_token(params[:confirmation_token])
-    # Handling errors if confirmation_token is valid
-    post_checks
   end
 
   def password_params
     params.require(:user).permit(:password, :password_confirmation)
   end
 
-  def post_checks
-    if @user
-      if !@user.confirmed_at.nil?
-        flash[:notice] = "Email address already confirmed, please sign in."
-        sign_out current_user
-        # To stop users using multiple confirmation links if signed in with one account already.
-        redirect_to new_user_session_path
-      elsif @user.id.nil?
+  def pre_checks
+    if params[:confirmation_token].blank?
+      flash[:notice] = 'Missing confirmation token. Please contact your administrator to resend confirmation instructions.'
+      redirect_to '/'
+      return
+    end
+    @found_user = User.find_or_initialize_with_error_by(:confirmation_token, params[:confirmation_token])
+    if @found_user
+      if @found_user.id.nil?
         flash[:notice] = 'Invalid confirmation token. Please contact your administrator to resend confirmation instructions.'
         redirect_to '/'
+      elsif !@found_user.confirmed_at.nil?
+        sign_out current_user
+        # To stop users using multiple confirmation links if signed in with one account already.
+        flash[:notice] = "Email address already confirmed, please sign in."
+        redirect_to new_user_session_path
       end
     end
+    # raise
   end
 end

--- a/app/controllers/confirmations_controller.rb
+++ b/app/controllers/confirmations_controller.rb
@@ -18,9 +18,10 @@ class ConfirmationsController < Devise::ConfirmationsController
   private
 
   def set_user
-    if !params[:confirmation_token] || params[:confirmation_token].empty?
+    if params[:confirmation_token].blank?
       flash[:notice] = 'Missing confirmation token. Please contact your administrator to resend confirmation instructions.'
       redirect_to '/'
+      return
     end
     @user = User.confirm_by_token(params[:confirmation_token])
     # Handling errors if confirmation_token is valid

--- a/app/controllers/confirmations_controller.rb
+++ b/app/controllers/confirmations_controller.rb
@@ -23,15 +23,23 @@ class ConfirmationsController < Devise::ConfirmationsController
       redirect_to '/'
     end
     @user = User.confirm_by_token(params[:confirmation_token])
-    # If confirm_by_token cannot find user
-    if @user.id.nil?
-      flash[:notice] = 'Invalid confirmation token. Please contact your administrator to resend confirmation instructions.'
-      redirect_to '/'
-    end
+    # Handling errors if confirmation_token is valid
+    post_checks
   end
 
   def password_params
     params.require(:user).permit(:password, :password_confirmation)
   end
 
+  def post_checks
+    if @user
+      if !@user.confirmed_at.nil?
+        flash[:notice] = "Email address already confirmed, please sign in."
+        redirect_to comfy_admin_cms_path
+      elsif @user.id.nil?
+        flash[:notice] = 'Invalid confirmation token. Please contact your administrator to resend confirmation instructions.'
+        redirect_to '/'
+      end
+    end
+  end
 end

--- a/app/controllers/confirmations_controller.rb
+++ b/app/controllers/confirmations_controller.rb
@@ -18,8 +18,10 @@ class ConfirmationsController < Devise::ConfirmationsController
   private
 
   def set_user
-    token = Devise.token_generator.digest(User, :confirmation_token, params[:confirmation_token])
-    @user = User.find_by_confirmation_token!(token)
+    # token = Devise.token_generator.digest(User, :confirmation_token, params[:confirmation_token])
+    # @user = User.find_by_confirmation_token!(token)
+    token = params[:confirmation_token]
+    @user = User.confirm_by_token(token)
   end
 
   def password_params

--- a/app/controllers/confirmations_controller.rb
+++ b/app/controllers/confirmations_controller.rb
@@ -1,7 +1,6 @@
 class ConfirmationsController < Devise::ConfirmationsController
   skip_before_filter :authenticate_user!
-  before_action :pre_checks, only: :show
-  before_action :set_user_update, only: :update
+  before_action :pre_checks, only: [:show, :update]
 
   def update
     if @user.update(password_params)
@@ -18,33 +17,26 @@ class ConfirmationsController < Devise::ConfirmationsController
 
   private
 
-  def set_user_update
-    # No checks as user must pass confirmation to see the show page - and ergo to update their password
-    @user = User.confirm_by_token(params[:confirmation_token])
-  end
-
   def password_params
     params.require(:user).permit(:password, :password_confirmation)
   end
 
   def pre_checks
-    @found_user = User.find_or_initialize_with_error_by(:confirmation_token, params[:confirmation_token])
-    if @found_user
-      if @found_user.id.nil?
-        flash[:error] = 'Invalid or already confirmed confirmation token. Please contact your administrator to resend confirmation instructions.'
-        redirect_to '/'
-        return
-      elsif !@found_user.id.nil?
-        if @found_user != current_user && !@found_user.confirmed_at.nil?
-          sign_out current_user
-          # To stop users using multiple confirmation links if signed in with one account already.
-          flash[:notice] = "Account already confirmed. Please sign in (again if you have been logged out)."
-          redirect_to new_user_session_path
+    @user = User.find_or_initialize_with_error_by(:confirmation_token, params[:confirmation_token])
+    if @user.id.nil? || !user_signed_in? && !@user.confirmed_at.nil?
+      flash[:error] = 'Invalid or already confirmed confirmation token. Please contact your administrator to resend confirmation instructions.'
+      redirect_to '/'
+      return
+    else
+      if @user != current_user && user_signed_in?
+        sign_out current_user
+        # To stop users using multiple confirmation links if signed in with one account already.
+        if @user.confirmed_at.nil?
+          flash[:error] = "Please confirm your new account."
+        else
+          flash[:error] = "Account already confirmed. Please contact your administrator to resend confirmation instructions."
+          redirect_to '/'
           return
-        elsif @found_user != current_user && @found_user.confirmed_at.nil?
-          sign_out current_user
-          flash[:notice] = "Signed you out. Please confirm your new account."
-          @user = User.confirm_by_token(params[:confirmation_token])
         end
       end
     end

--- a/app/controllers/confirmations_controller.rb
+++ b/app/controllers/confirmations_controller.rb
@@ -28,19 +28,19 @@ class ConfirmationsController < Devise::ConfirmationsController
 
   def pre_checks
     if params[:confirmation_token].blank?
-      flash[:notice] = 'Missing confirmation token. Please contact your administrator to resend confirmation instructions.'
+      flash[:error] = 'Missing confirmation token. Please contact your administrator to resend confirmation instructions.'
       redirect_to '/'
       return
     end
     @found_user = User.find_or_initialize_with_error_by(:confirmation_token, params[:confirmation_token])
     if @found_user
       if @found_user.id.nil?
-        flash[:notice] = 'Invalid confirmation token. Please contact your administrator to resend confirmation instructions.'
+        flash[:error] = 'Invalid confirmation token. Please contact your administrator to resend confirmation instructions.'
         redirect_to '/'
       elsif !@found_user.confirmed_at.nil?
         sign_out current_user
         # To stop users using multiple confirmation links if signed in with one account already.
-        flash[:notice] = "Email address already confirmed, please sign in."
+        flash[:error] = "Email address already confirmed, please sign in."
         redirect_to new_user_session_path
       end
     end

--- a/app/controllers/confirmations_controller.rb
+++ b/app/controllers/confirmations_controller.rb
@@ -1,6 +1,7 @@
 class ConfirmationsController < Devise::ConfirmationsController
   skip_before_filter :authenticate_user!
-  before_action :set_user, only: [:show, :update]
+  before_action :pre_checks, only: :show
+  before_action :set_user_update, only: :update
 
   def update
     if @user.update(password_params)
@@ -17,8 +18,8 @@ class ConfirmationsController < Devise::ConfirmationsController
 
   private
 
-  def set_user
-    pre_checks
+  def set_user_update
+    # No checks as user must pass confirmation to see the show page - and ergo to update their password
     @user = User.confirm_by_token(params[:confirmation_token])
   end
 
@@ -27,21 +28,24 @@ class ConfirmationsController < Devise::ConfirmationsController
   end
 
   def pre_checks
-    if params[:confirmation_token].blank?
-      flash[:error] = 'Missing confirmation token. Please contact your administrator to resend confirmation instructions.'
-      redirect_to '/'
-      return
-    end
     @found_user = User.find_or_initialize_with_error_by(:confirmation_token, params[:confirmation_token])
     if @found_user
       if @found_user.id.nil?
-        flash[:error] = 'Invalid confirmation token. Please contact your administrator to resend confirmation instructions.'
+        flash[:error] = 'Invalid or already confirmed confirmation token. Please contact your administrator to resend confirmation instructions.'
         redirect_to '/'
-      elsif !@found_user.confirmed_at.nil?
-        sign_out current_user
-        # To stop users using multiple confirmation links if signed in with one account already.
-        flash[:error] = "Email address already confirmed, please sign in."
-        redirect_to new_user_session_path
+        return
+      elsif !@found_user.id.nil?
+        if @found_user != current_user && !@found_user.confirmed_at.nil?
+          sign_out current_user
+          # To stop users using multiple confirmation links if signed in with one account already.
+          flash[:notice] = "Account already confirmed. Please sign in (again if you have been logged out)."
+          redirect_to new_user_session_path
+          return
+        elsif @found_user != current_user && @found_user.confirmed_at.nil?
+          sign_out current_user
+          flash[:notice] = "Signed you out. Please confirm your new account."
+          @user = User.confirm_by_token(params[:confirmation_token])
+        end
       end
     end
   end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -29,7 +29,7 @@ UnepWcmcOrg::Application.configure do
   # number of complex assets.
   config.assets.debug = true
 
-  config.action_mailer.default_url_options = { :host => '127.0.0.1:3000' }
+  config.action_mailer.default_url_options = { :host => 'localhost:3000' }
 
 
 end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -17,7 +17,6 @@ UnepWcmcOrg::Application.configure do
   config.action_mailer.raise_delivery_errors = false
 
   config.action_mailer.delivery_method = :letter_opener
-  # config.action_mailer.delivery_method = :smtp - was testing with this as letter_opener wasn't working
 
   # Print deprecation notices to the Rails logger.
   config.active_support.deprecation = :log
@@ -30,7 +29,7 @@ UnepWcmcOrg::Application.configure do
   # number of complex assets.
   config.assets.debug = true
 
-  config.action_mailer.default_url_options = { :host => 'localhost:3000' }
+  config.action_mailer.default_url_options = { :host => '127.0.0.1:3000' }
 
 
 end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -17,6 +17,7 @@ UnepWcmcOrg::Application.configure do
   config.action_mailer.raise_delivery_errors = false
 
   config.action_mailer.delivery_method = :letter_opener
+  # config.action_mailer.delivery_method = :smtp - was testing with this as letter_opener wasn't working
 
   # Print deprecation notices to the Rails logger.
   config.active_support.deprecation = :log
@@ -29,6 +30,7 @@ UnepWcmcOrg::Application.configure do
   # number of complex assets.
   config.assets.debug = true
 
-  config.action_mailer.default_url_options = { :host => '127.0.0.1:3000' }
+  config.action_mailer.default_url_options = { :host => 'localhost:3000' }
+
 
 end


### PR DESCRIPTION
https://unep-wcmc.codebasehq.com/projects/bits-and-bugs/tickets/8
Rather than using find_by_confirmation_token this uses Devise's own class method confirm_by_token to confirm users. I wasn't able to identify why the existing method was no longer working even after testing in the console because the line `User.find_by_confirmation_token!(token)` was attempting to match the digested token to the unencrypted token saved on each user instance.