### PR TITLE
Confirmation email fix

### DIFF
--- a/app/controllers/submissions_controller.rb
+++ b/app/controllers/submissions_controller.rb
@@ -85,7 +85,7 @@ class SubmissionsController < ApplicationController
   def send_confirmation_email
     if params[:submit]
       SubmissionMailer.submit_confirmation(@submission, @form).deliver_now
-      SubmissionMailer.inform_recruitment(@submission, @form).deliver_now
+      # SubmissionMailer.inform_recruitment(@submission, @form).deliver_now
     else
       SubmissionMailer.save_confirmation(@submission, @form).deliver_now
     end

--- a/app/controllers/submissions_controller.rb
+++ b/app/controllers/submissions_controller.rb
@@ -84,10 +84,10 @@ class SubmissionsController < ApplicationController
 
   def send_confirmation_email
     if params[:submit]
-      SubmissionMailer.submit_confirmation(@submission, @form).deliver_later
-      SubmissionMailer.inform_recruitment(@submission, @form).deliver_later
+      SubmissionMailer.submit_confirmation(@submission, @form).deliver_now
+      SubmissionMailer.inform_recruitment(@submission, @form).deliver_now
     else
-      SubmissionMailer.save_confirmation(@submission, @form).deliver_later
+      SubmissionMailer.save_confirmation(@submission, @form).deliver_now
     end
   end
 

--- a/app/controllers/submissions_controller.rb
+++ b/app/controllers/submissions_controller.rb
@@ -85,7 +85,7 @@ class SubmissionsController < ApplicationController
   def send_confirmation_email
     if params[:submit]
       SubmissionMailer.submit_confirmation(@submission, @form).deliver_now
-      # SubmissionMailer.inform_recruitment(@submission, @form).deliver_now
+      SubmissionMailer.inform_recruitment(@submission, @form).deliver_now
     else
       SubmissionMailer.save_confirmation(@submission, @form).deliver_now
     end

--- a/app/mailers/submission_mailer.rb
+++ b/app/mailers/submission_mailer.rb
@@ -10,7 +10,7 @@ class SubmissionMailer < ActionMailer::Base
   def submit_confirmation(submission, form)
     @submission = submission
     @form = form
-    mail(to: submission.email, from: 'no-reply@unep-wcmc.org', subject: 'Job application submitted.')
+    mail(from: 'no-reply@unep-wcmc.org', to: submission.email, subject: 'Job application submitted.')
   end
 
   def inform_recruitment(submission, form)

--- a/app/mailers/submission_mailer.rb
+++ b/app/mailers/submission_mailer.rb
@@ -3,14 +3,14 @@ class SubmissionMailer < ActionMailer::Base
     @submission = submission
     @form = form
     if submission.saved_first_time?
-      mail(from: 'no-reply@unep-wcmc.org', to: submission.email, subject: 'Job application saved.').deliver
+      mail(from: 'no-reply@unep-wcmc.org', to: submission.email, subject: 'Job application saved.')
     end
   end
 
   def submit_confirmation(submission, form)
     @submission = submission
     @form = form
-    mail(from: 'no-reply@unep-wcmc.org', to: submission.email, subject: 'Job application submitted.').deliver
+    mail(to: submission.email, from: 'no-reply@unep-wcmc.org', subject: 'Job application submitted.')
   end
 
   def inform_recruitment(submission, form)
@@ -24,6 +24,6 @@ class SubmissionMailer < ActionMailer::Base
       to: 'recruitment@unep-wcmc.org',
       subject: "Job Application submitted: #{@vacancy.label},
         #{@submission.name} (#{@submission.email})"
-    ).deliver
+    )
   end
 end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -1,6 +1,6 @@
+secrets = Rails.application.secrets
 UnepWcmcOrg::Application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
-
   # In the development environment your application's code is reloaded on
   # every request. This slows down response time but is perfect for development
   # since you don't have to restart the web server when you make code changes.
@@ -14,9 +14,7 @@ UnepWcmcOrg::Application.configure do
   config.action_controller.perform_caching = false
 
   # Don't care if the mailer can't send.
-  config.action_mailer.raise_delivery_errors = false
-
-  config.action_mailer.delivery_method = :letter_opener
+  config.action_mailer.raise_delivery_errors = true
 
   # Print deprecation notices to the Rails logger.
   config.active_support.deprecation = :log
@@ -29,7 +27,20 @@ UnepWcmcOrg::Application.configure do
   # number of complex assets.
   config.assets.debug = true
 
-  config.action_mailer.default_url_options = { :host => 'localhost:3000' }
+  
+  config.action_mailer.delivery_method = :smtp #for the mac apparently run::sudo postfix start
+  config.action_mailer.asset_host = secrets['mailer']['asset_host']
+  config.action_mailer.default_url_options = { :host => 'localhost:3000', :protocol => 'http' }
 
+  
+  config.action_mailer.smtp_settings = {
+    :enable_starttls_auto => true,
+    :address => secrets['mailer']['address'],
+    :port => secrets['mailer']['port'],
+    :domain => secrets['mailer']['domain'],
+    :authentication => :login,
+    :user_name => secrets['mailer']['username'],
+    :password => secrets['mailer']['password']
+  }
 
 end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -13,7 +13,7 @@ UnepWcmcOrg::Application.configure do
   config.consider_all_requests_local       = true
   config.action_controller.perform_caching = false
 
-  # Don't care if the mailer can't send.
+
   config.action_mailer.raise_delivery_errors = true
 
   # Print deprecation notices to the Rails logger.
@@ -32,7 +32,7 @@ UnepWcmcOrg::Application.configure do
 
 
   config.action_mailer.default_url_options = { :host => 'localhost:3000', :protocol => 'http' }
-
+  config.action_mailer.perform_deliveries = true
 
 
 end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -28,19 +28,11 @@ UnepWcmcOrg::Application.configure do
   config.assets.debug = true
 
   
-  config.action_mailer.delivery_method = :smtp #for the mac apparently run::sudo postfix start
-  config.action_mailer.asset_host = secrets['mailer']['asset_host']
+  config.action_mailer.delivery_method = :letter_opener
+
+
   config.action_mailer.default_url_options = { :host => 'localhost:3000', :protocol => 'http' }
 
-  
-  config.action_mailer.smtp_settings = {
-    :enable_starttls_auto => true,
-    :address => secrets['mailer']['address'],
-    :port => secrets['mailer']['port'],
-    :domain => secrets['mailer']['domain'],
-    :authentication => :login,
-    :user_name => secrets['mailer']['username'],
-    :password => secrets['mailer']['password']
-  }
+
 
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -1,6 +1,7 @@
+secrets = Rails.application.secrets
 UnepWcmcOrg::Application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
-  secrets = Rails.application.secrets
+  
 
   # Code is not reloaded between requests.
   config.cache_classes = true

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -1,6 +1,6 @@
-secrets = Rails.application.secrets.mailer
 UnepWcmcOrg::Application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
+  secrets = Rails.application.secrets
 
   # Code is not reloaded between requests.
   config.cache_classes = true
@@ -70,16 +70,16 @@ UnepWcmcOrg::Application.configure do
   # config.action_mailer.raise_delivery_errors = false
 
   config.action_mailer.delivery_method = :smtp #for the mac apparently run::sudo postfix start
-  config.action_mailer.asset_host = secrets['asset_host']
-  config.action_mailer.default_url_options = { :host => secrets['host'] }
+  config.action_mailer.asset_host = secrets['mailer']['asset_host']
+  config.action_mailer.default_url_options = { :host => secrets['mailer']['host'] }
   config.action_mailer.smtp_settings = {
     :enable_starttls_auto => true,
-    :address => secrets['address'],
-    :port => secrets['port'],
-    :domain => secrets['domain'],
+    :address => secrets['mailer']['address'],
+    :port => secrets['mailer']['port'],
+    :domain => secrets['mailer']['domain'],
     :authentication => :login,
-    :user_name => secrets['username'],
-    :password => secrets['password']
+    :user_name => secrets['mailer']['username'],
+    :password => secrets['mailer']['password']
   }
 
   # Enable locale fallbacks for I18n (makes lookups for any locale fall back to

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -12,14 +12,6 @@ default_dashboard_urls: &default_dashboard_urls
 
 development:
   secret_key_base: '4ab6dc786dc1904ea29b04aee5c6f25d4fbfdc9672ea569dde62b92a4fbfe2a2f698818004cfb31c83420b35a11c150c1601498cd630f387f38c3b970616d742'
-  mailer:
-    address: <%= ENV["MAILER_ADDRESS_KEY"] || "" %>
-    port: <%= ENV["MAILER_PORT_KEY"] || "" %>
-    domain: <%= ENV["MAILER_DOMAIN_KEY"] || "" %>
-    username: <%= ENV["MAILER_USERNAME_KEY"] || "" %>
-    password: <%= ENV["MAILER_PASSWORD_KEY"] || "" %>
-    asset_host: <%= ENV["MAILER_ASSET_HOST_KEY"] || "" %>
-    host: <%= ENV["MAILER_HOST_KEY"] || "" %>
   
   max_mind:
     country_db : '/usr/share/GeoIP/GeoIP.dat'

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -12,6 +12,15 @@ default_dashboard_urls: &default_dashboard_urls
 
 development:
   secret_key_base: '4ab6dc786dc1904ea29b04aee5c6f25d4fbfdc9672ea569dde62b92a4fbfe2a2f698818004cfb31c83420b35a11c150c1601498cd630f387f38c3b970616d742'
+  mailer:
+    address: <%= ENV["MAILER_ADDRESS_KEY"] || "" %>
+    port: <%= ENV["MAILER_PORT_KEY"] || "" %>
+    domain: <%= ENV["MAILER_DOMAIN_KEY"] || "" %>
+    username: <%= ENV["MAILER_USERNAME_KEY"] || "" %>
+    password: <%= ENV["MAILER_PASSWORD_KEY"] || "" %>
+    asset_host: <%= ENV["MAILER_ASSET_HOST_KEY"] || "" %>
+    host: <%= ENV["MAILER_HOST_KEY"] || "" %>
+  
   max_mind:
     country_db : '/usr/share/GeoIP/GeoIP.dat'
   capistrano_slack: ''


### PR DESCRIPTION
**Ticket**

https://unep-wcmc.codebasehq.com/projects/bits-and-bugs/tickets/15

Noted that there were redundant `.deliver` methods being called in the submissions mailer when the submissions controller was already calling `.deliver_later` - somehow the confirmation emails were still being sent to recruitment. In any case, `.deliver_later` was not being used properly as it relies on Rails' background jobs feature, Active Job, to enqueue emails - but there was no such job in the code. The `.deliver` method is also deprecated in Rails 5. I've replaced `.deliver_later` with `.deliver_now` instead.

@will-kocur could you start the server in development and try submitting a dummy application with `SubmissionMailer.inform_recruitment(@submission, @form).deliver_now` in `submission_controller.rb` commented out so that recruitment don't get wrongly informed? If you set up a GuerrillaMail account and use that as your email address you should be able to receive confirmation emails. 

I will strip `development.rb` and `secrets.yml` of the lines containing secrets once I get confirmation that it works locally.