### PR TITLE
fixed issue to do with multiple resources being pulled in

### DIFF
--- a/app/assets/javascripts/pages/datasets_resources/datasets_ctrl.js
+++ b/app/assets/javascripts/pages/datasets_resources/datasets_ctrl.js
@@ -8,7 +8,6 @@ function ($scope, $sce) {
 
   var index = lunr(function () {
     this.field('title', {boost: 10});
-    this.field('content');
     this.ref('index');
   });
 


### PR DESCRIPTION
**Ticket** 

https://unep-wcmc.codebasehq.com/projects/bits-and-bugs/tickets/6

Have fixed search in the Resources and Data section to only pull in search terms found in the title, the downside being that users cannot search for words in the content anymore of each resource. Let me know if this is acceptable. 

The other solution is that we alter the slugs of the affected pages to be more specific, thereby preventing other results from being pulled in, e.g renaming 'planning-for-redd-benefits-beyond-carbon' to 'planning-for-redd-benefits-beyond-carbon-flyer'