### PR TITLE
Featured projects page doesn't break if no images are present for a project

### DIFF
--- a/app/views/featured_projects/_project.html.erb
+++ b/app/views/featured_projects/_project.html.erb
@@ -1,7 +1,9 @@
 <section class="flex--2-cols__child">
-  <% if cms_block_content(:thumbnail, page).file.present? %>
-    <%= link_to @cms_site.path + page.full_path do %>
-      <%= image_tag cms_block_content(:thumbnail, page).file.url(:thumbnail) %>
+  <% unless cms_block_content(:thumbnail, page).nil? %>
+    <% if cms_block_content(:thumbnail, page).file.present? %>
+      <%= link_to @cms_site.path + page.full_path do %>
+        <%= image_tag cms_block_content(:thumbnail, page).file.url(:thumbnail) %>
+      <% end %>
     <% end %>
   <% end %>
   <h2 class="smaller">


### PR DESCRIPTION
Ticket: https://unep-wcmc.codebasehq.com/projects/bits-and-bugs/tickets/22

I had two choices here, 1) to allow the Featured Projects to load for projects without any attached images, or 2) to add validations to the pages before saving to ensure that they had the necessary photos attached. Option 2 was deemed to be harder because it involved sending the validation to the page model in the Comfy gem which doesn't always go smoothly, so I went with 1). 