### PR TITLE
Confirmation email fix revisited

### DIFF
--- a/app/controllers/submissions_controller.rb
+++ b/app/controllers/submissions_controller.rb
@@ -85,7 +85,7 @@ class SubmissionsController < ApplicationController
   def send_confirmation_email
     if params[:submit]
       SubmissionMailer.submit_confirmation(@submission, @form).deliver_now
-      SubmissionMailer.inform_recruitment(@submission, @form).deliver_now
+      # SubmissionMailer.inform_recruitment(@submission, @form).deliver_now
     else
       SubmissionMailer.save_confirmation(@submission, @form).deliver_now
     end

--- a/app/controllers/submissions_controller.rb
+++ b/app/controllers/submissions_controller.rb
@@ -85,7 +85,7 @@ class SubmissionsController < ApplicationController
   def send_confirmation_email
     if params[:submit]
       SubmissionMailer.submit_confirmation(@submission, @form).deliver_now
-      # SubmissionMailer.inform_recruitment(@submission, @form).deliver_now
+      SubmissionMailer.inform_recruitment(@submission, @form).deliver_now
     else
       SubmissionMailer.save_confirmation(@submission, @form).deliver_now
     end

--- a/app/mailers/submission_mailer.rb
+++ b/app/mailers/submission_mailer.rb
@@ -25,7 +25,7 @@ class SubmissionMailer < ActionMailer::Base
 
     mail(
       from: 'no-reply@unep-wcmc.org',
-      to: 'stanley.liu@unep-wcmc.org',
+      to: 'recruitment@unep-wcmc.org',
       subject: "Job Application submitted: #{@vacancy.label},
         #{@submission.name} (#{@submission.email})"
     )

--- a/app/mailers/submission_mailer.rb
+++ b/app/mailers/submission_mailer.rb
@@ -1,4 +1,8 @@
+require 'digest/sha2'
+
 class SubmissionMailer < ActionMailer::Base
+  default "Message-ID" => lambda {"<#{Digest::SHA2.hexdigest(Time.now.to_i.to_s)}@unep-wcmc.org>"}
+
   def save_confirmation(submission, form)
     @submission = submission
     @form = form

--- a/app/mailers/submission_mailer.rb
+++ b/app/mailers/submission_mailer.rb
@@ -21,7 +21,7 @@ class SubmissionMailer < ActionMailer::Base
 
     mail(
       from: 'no-reply@unep-wcmc.org',
-      to: 'recruitment@unep-wcmc.org',
+      to: 'stanley.liu@unep-wcmc.org',
       subject: "Job Application submitted: #{@vacancy.label},
         #{@submission.name} (#{@submission.email})"
     )

--- a/app/mailers/submission_mailer.rb
+++ b/app/mailers/submission_mailer.rb
@@ -1,7 +1,7 @@
 require 'digest/sha2'
 
 class SubmissionMailer < ActionMailer::Base
-  default "Message-ID" => lambda {"<#{Digest::SHA2.hexdigest(Time.now.to_i.to_s)}@unep-wcmc.org>"}
+  default "Message-ID" => proc {"<#{Digest::SHA2.hexdigest(Time.now.to_i.to_s)}@unep-wcmc.org>"}
 
   def save_confirmation(submission, form)
     @submission = submission

--- a/app/views/submission_mailer/save_confirmation.html.erb
+++ b/app/views/submission_mailer/save_confirmation.html.erb
@@ -1,0 +1,8 @@
+<p>Dear <%= @submission.name %>,</p>
+
+<p>
+Your job application has been saved. You can still edit it <%= link_to 'here', edit_form_submission_url(@form, @submission) %>
+</p>
+
+<p>Yours sincerely,</p>
+<p>The UNEP-WCMC team</p>

--- a/app/views/submission_mailer/save_confirmation.html.erb
+++ b/app/views/submission_mailer/save_confirmation.html.erb
@@ -1,8 +1,3 @@
-<p>Dear <%= @submission.name %>,</p>
-
 <p>
-Your job application has been saved. You can still edit it <%= link_to 'here', edit_form_submission_url(@form, @submission) %>
+Your job application has been saved. You can still edit it <%= link_to 'here', edit_form_submission_url(@form, @submission) %>.
 </p>
-
-<p>Yours sincerely,</p>
-<p>The UNEP-WCMC team</p>

--- a/app/views/submission_mailer/save_confirmation.html.haml
+++ b/app/views/submission_mailer/save_confirmation.html.haml
@@ -1,1 +1,0 @@
-Your job application has been saved. You can still edit it #{link_to 'here', edit_form_submission_url(@form, @submission)}.

--- a/app/views/submission_mailer/save_confirmation.text.erb
+++ b/app/views/submission_mailer/save_confirmation.text.erb
@@ -1,0 +1,6 @@
+Dear <%= @submission.name %>,
+
+Your job application has been saved. You can still edit it <%= link_to 'here', edit_form_submission_url(@form, @submission) %>
+
+Yours sincerely,
+The UNEP-WCMC team

--- a/app/views/submission_mailer/save_confirmation.text.erb
+++ b/app/views/submission_mailer/save_confirmation.text.erb
@@ -1,6 +1,1 @@
-Dear <%= @submission.name %>,
-
-Your job application has been saved. You can still edit it <%= link_to 'here', edit_form_submission_url(@form, @submission) %>
-
-Yours sincerely,
-The UNEP-WCMC team
+Your job application has been saved. You can still edit it <%= link_to 'here', edit_form_submission_url(@form, @submission) %>.

--- a/app/views/submission_mailer/submit_confirmation.html.erb
+++ b/app/views/submission_mailer/submit_confirmation.html.erb
@@ -1,10 +1,5 @@
-<p>Dear <%= @submission.name %>,</p>
-
 <p>
   Thank you for submitting your job application. Please note that you can't edit the application anymore.
-  You can view your submission <%= link_to 'here', form_submission_url(@form, @submission) %>
+  You can view your submission <%= link_to 'here', form_submission_url(@form, @submission) %>.
   We will be shortlisting applications following the closing date and will be in contact with you to confirm the outcome of your application.
 </p>
-
-<p>Yours sincerely,</p>
-<p>The UNEP-WCMC team</p>

--- a/app/views/submission_mailer/submit_confirmation.html.erb
+++ b/app/views/submission_mailer/submit_confirmation.html.erb
@@ -1,0 +1,10 @@
+<p>Dear <%= @submission.name %>,</p>
+
+<p>
+  Thank you for submitting your job application. Please note that you can't edit the application anymore.
+  You can view your submission <%= link_to 'here', form_submission_url(@form, @submission) %>
+  We will be shortlisting applications following the closing date and will be in contact with you to confirm the outcome of your application.
+</p>
+
+<p>Yours sincerely,</p>
+<p>The UNEP-WCMC team</p>

--- a/app/views/submission_mailer/submit_confirmation.text.erb
+++ b/app/views/submission_mailer/submit_confirmation.text.erb
@@ -1,8 +1,3 @@
-Dear <%= @submission.name %>
-
 Thank you for submitting your job application. Please note that you can't edit the application anymore.
-You can view your submission <%= link_to 'here', form_submission_url(@form, @submission) %>
+You can view your submission <%= link_to 'here', form_submission_url(@form, @submission) %>.
 We will be shortlisting applications following the closing date and will be in contact with you to confirm the outcome of your application.
-
-Yours sincerely,
-The UNEP-WCMC team

--- a/app/views/submission_mailer/submit_confirmation.text.erb
+++ b/app/views/submission_mailer/submit_confirmation.text.erb
@@ -1,3 +1,8 @@
+Dear <%= @submission.name %>
+
 Thank you for submitting your job application. Please note that you can't edit the application anymore.
-You can view your submission #{link_to 'here', form_submission_url(@form, @submission)}.
+You can view your submission <%= link_to 'here', form_submission_url(@form, @submission) %>
 We will be shortlisting applications following the closing date and will be in contact with you to confirm the outcome of your application.
+
+Yours sincerely,
+The UNEP-WCMC team

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -1,5 +1,5 @@
 # config valid only for current version of Capistrano
-lock '3.4.0'
+lock '3.5.0'
 
 set :application, 'unepwcmc'
 set :repo_url, 'git@github.com:unepwcmc/unep-wcmc.org'

--- a/config/deploy/staging.rb
+++ b/config/deploy/staging.rb
@@ -8,7 +8,7 @@
 # server 'db.example.com', user: 'deploy', roles: %w{db}
 
 set :stage, :staging
-set :branch, "master"
+set :branch, "confirmation-email-fix-revisited"
 
 
 server "unep-wcmc-staging.linode.unep-wcmc.org", user: 'wcmc', roles: %w{app web db}

--- a/config/deploy/staging.rb
+++ b/config/deploy/staging.rb
@@ -8,7 +8,7 @@
 # server 'db.example.com', user: 'deploy', roles: %w{db}
 
 set :stage, :staging
-set :branch, "confirmation-email-fix-revisited"
+set :branch, "develop"
 
 
 server "unep-wcmc-staging.linode.unep-wcmc.org", user: 'wcmc', roles: %w{app web db}

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -70,10 +70,10 @@ UnepWcmcOrg::Application.configure do
   # Set this to true and configure the email server for immediate delivery to raise delivery errors.
   # config.action_mailer.raise_delivery_errors = false
 
-  config.action_mailer.delivery_method = :smtp #for the mac apparently run::sudo postfix start
+  config.action_mailer.delivery_method = :sendmail #for the mac apparently run::sudo postfix start
   config.action_mailer.asset_host = secrets['mailer']['asset_host']
   config.action_mailer.default_url_options = { :host => secrets['mailer']['host'] }
-  config.action_mailer.smtp_settings = {
+  config.action_mailer.sendmail_settings = {
     :enable_starttls_auto => true,
     :address => secrets['mailer']['address'],
     :port => secrets['mailer']['port'],

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -82,6 +82,9 @@ UnepWcmcOrg::Application.configure do
     :password => secrets['password']
   }
 
+  config.action_mailer.raise_delivery_errors = true
+  config.action_mailer.perform_deliveries = true
+
   # Enable locale fallbacks for I18n (makes lookups for any locale fall back to
   # the I18n.default_locale when a translation can not be found).
   config.i18n.fallbacks = true

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -69,10 +69,10 @@ UnepWcmcOrg::Application.configure do
   # Set this to true and configure the email server for immediate delivery to raise delivery errors.
   # config.action_mailer.raise_delivery_errors = false
 
-  config.action_mailer.delivery_method = :smtp #for the mac apparently run::sudo postfix start
+  config.action_mailer.delivery_method = :sendmail #for the mac apparently run::sudo postfix start
   config.action_mailer.asset_host = secrets['asset_host']
   config.action_mailer.default_url_options = { :host => secrets['host'] }
-  config.action_mailer.smtp_settings = {
+  config.action_mailer.sendmail_settings = {
     :enable_starttls_auto => true,
     :address => secrets['address'],
     :port => secrets['port'],


### PR DESCRIPTION
**Ticket**

https://unep-wcmc.codebasehq.com/projects/bits-and-bugs/tickets/15 (revisit)

Fix for Gmail users who were unable to receive confirmation emails upon submitting job applications. Users of other email domains were unaffected. 

This is currently deployed on staging and has previously tested there, but if you want to test it yourself, comment out the call to `inform_recruitment` in the Submissions controller as recruitment will receive alerts upon any job submissions. 