### PR TITLE
Fix/emails revisited part ii

### DIFF
--- a/app/controllers/submissions_controller.rb
+++ b/app/controllers/submissions_controller.rb
@@ -86,7 +86,7 @@ class SubmissionsController < ApplicationController
   def send_confirmation_email
     if params[:submit]
       SubmissionMailer.submit_confirmation(@submission, @form).deliver_now
-      # SubmissionMailer.inform_recruitment(@submission, @form).deliver_now
+      SubmissionMailer.inform_recruitment(@submission, @form).deliver_now
     else
       SubmissionMailer.save_confirmation(@submission, @form).deliver_now
     end

--- a/app/controllers/submissions_controller.rb
+++ b/app/controllers/submissions_controller.rb
@@ -86,7 +86,7 @@ class SubmissionsController < ApplicationController
   def send_confirmation_email
     if params[:submit]
       SubmissionMailer.submit_confirmation(@submission, @form).deliver_now
-      SubmissionMailer.inform_recruitment(@submission, @form).deliver_now
+      # SubmissionMailer.inform_recruitment(@submission, @form).deliver_now
     else
       SubmissionMailer.save_confirmation(@submission, @form).deliver_now
     end

--- a/app/mailers/submission_mailer.rb
+++ b/app/mailers/submission_mailer.rb
@@ -1,7 +1,7 @@
 require 'digest/sha2'
 
 class SubmissionMailer < ActionMailer::Base
-  default "Message-ID" => proc {"<#{Digest::SHA2.hexdigest(Time.now.to_i.to_s)}@unep-wcmc.org>"}
+  # default "Message-ID" => proc {"<#{Digest::SHA2.hexdigest(Time.now.to_i.to_s)}@unep-wcmc.org>"}
 
   def save_confirmation(submission, form)
     @submission = submission

--- a/app/mailers/submission_mailer.rb
+++ b/app/mailers/submission_mailer.rb
@@ -1,7 +1,4 @@
-require 'digest/sha2'
-
 class SubmissionMailer < ActionMailer::Base
-  # default "Message-ID" => proc {"<#{Digest::SHA2.hexdigest(Time.now.to_i.to_s)}@unep-wcmc.org>"}
 
   def save_confirmation(submission, form)
     @submission = submission


### PR DESCRIPTION
**Ticket**

https://unep-wcmc.codebasehq.com/projects/bits-and-bugs/tickets/38 

Removed the 'Message-ID' header which was hex encoded which iCloud doesn't like, other email domains still work. 