### PR TITLE
Fix/job applications zip

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -30,6 +30,8 @@ gem 'devise', '~> 3.5.6'
 gem 'appsignal'
 gem 'test-unit', '~> 3.1' # annoyingly, rails console won't start without it in staging / production
 
+gem 'rubyzip', '~> 1.3.0'
+
 group :development, :test do
   gem 'rspec-rails', '~> 2.14.2'
   gem 'guard'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -319,6 +319,7 @@ GEM
       rspec-mocks (~> 2.14.0)
     ruby_parser (3.7.1)
       sexp_processor (~> 4.1)
+    rubyzip (1.3.0)
     sass (3.4.18)
     sass-rails (5.0.4)
       railties (>= 4.0.0, < 5.0)
@@ -416,6 +417,7 @@ DEPENDENCIES
   rails (= 4.2.5.2)
   rails-observers
   rspec-rails (~> 2.14.2)
+  rubyzip (~> 1.3.0)
   sass-rails (~> 5.0.4)
   sdoc
   select2-rails (~> 3.5.9.3)
@@ -429,6 +431,3 @@ DEPENDENCIES
   underscore-rails
   whenever (~> 0.9.0)
   yajl-ruby (~> 1.2.1)
-
-BUNDLED WITH
-   1.10.6

--- a/app/controllers/job_applications_controller.rb
+++ b/app/controllers/job_applications_controller.rb
@@ -17,8 +17,8 @@ class JobApplicationsController < ApplicationController
     filename = "#{vacancy_label}.zip"
     zip = Download::GenerateZip.new(path, filename)
 
-    if ( zip.zip_needs_regenerating? last_uploaded_submission.updated_at ||
-      zip.zip_contents_mismatched?(form.submissions) )
+    if zip.zip_needs_regenerating?(last_uploaded_submission.updated_at) ||
+      zip.zip_contents_mismatched?(form.submissions) 
       zip.all_applications_generate_zip(form.id)
     end
 

--- a/app/controllers/job_applications_controller.rb
+++ b/app/controllers/job_applications_controller.rb
@@ -17,7 +17,8 @@ class JobApplicationsController < ApplicationController
     filename = "#{vacancy_label}.zip"
     zip = Download::GenerateZip.new(path, filename)
 
-    if zip.zip_needs_regenerating? last_uploaded_submission.updated_at
+    if ( zip.zip_needs_regenerating? last_uploaded_submission.updated_at ||
+      zip.zip_contents_mismatched?(form.submissions) )
       zip.all_applications_generate_zip(form.id)
     end
 

--- a/lib/download/generate_zip.rb
+++ b/lib/download/generate_zip.rb
@@ -115,8 +115,7 @@ class Download::GenerateZip
     # Need to account as well for the all_submissions folder that's generated
     number_of_applications = valid_submissions.pluck(:name).map(&:downcase).uniq.count + 1
 
-    # Subtract one because size takes into account the actual file itself
-    number_of_entries = Zip::File.open("#{@path}/#{@zip_path}").glob('*/*').count - 1
+    number_of_entries = Zip::File.open("#{@path}/#{@zip_path}").glob('*/*').count
 
     number_of_entries != number_of_applications
   end

--- a/lib/download/generate_zip.rb
+++ b/lib/download/generate_zip.rb
@@ -109,6 +109,8 @@ class Download::GenerateZip
   end
 
   def zip_contents_mismatched?(job_submissions)
+    return true unless File.exists?("#{@path}/#{@zip_path}")
+    
     valid_submissions = job_submissions.where.not(cv_file_name: nil, 
       cover_letter_file_name: nil, application_form_file_name: nil)
 

--- a/lib/download/generate_zip.rb
+++ b/lib/download/generate_zip.rb
@@ -114,10 +114,17 @@ class Download::GenerateZip
     valid_submissions = job_submissions.where.not(cv_file_name: nil, 
       cover_letter_file_name: nil, application_form_file_name: nil, is_submitted: false)
 
-    # Need to account as well for the all_submissions folder that's generated
-    number_of_applications = valid_submissions.pluck(:name).map(&:downcase).uniq.count + 1
+    number_of_applications = valid_submissions.pluck(:name).map(&:downcase).uniq.count 
+    
+    zip_file = Zip::File.open("#{@path}/#{@zip_path}")
 
-    number_of_entries = Zip::File.open("#{@path}/#{@zip_path}").glob('*/*').count
+    # Need to account as well for the all_submissions folder that's usually generated
+    number_of_entries = zip_file.glob('*/*').count
+    all_applications_folder = zip_file.entries.map(&:name).find do |folder|
+                                folder.split('/').last.gsub('/', '') == 'all_submissions'
+                              end
+
+    number_of_entries - 1 if all_applications_folder
 
     number_of_entries != number_of_applications
   end

--- a/lib/download/generate_zip.rb
+++ b/lib/download/generate_zip.rb
@@ -124,7 +124,7 @@ class Download::GenerateZip
                                 folder.split('/').last.gsub('/', '') == 'all_submissions'
                               end
 
-    number_of_entries - 1 if all_applications_folder
+    number_of_entries -= 1 if all_applications_folder
 
     number_of_entries != number_of_applications
   end

--- a/lib/download/generate_zip.rb
+++ b/lib/download/generate_zip.rb
@@ -106,6 +106,20 @@ class Download::GenerateZip
     zip_file_modification_time < last_uploaded_application_time
   end
 
+  def zip_contents_mismatched?(job_submissions)
+    # Need to account as well for the all_submissions folder that's generated
+    number_of_applications = job_submissions.pluck(:name).uniq.count + 1
+
+    number_of_entries = nil
+
+    Zip::File.open("#{@path}/#{@zip_path}") do |zip_file|
+      # Subtract one because size takes into account the actual file itself
+      number_of_entries = zip_file.size - 1
+    end
+
+    number_of_entries != number_of_applications
+  end
+
   def any_submissions_with_documents_valid? form
     form.submissions.each do |submission|
       return true if submission.attachments_valid?

--- a/lib/download/generate_zip.rb
+++ b/lib/download/generate_zip.rb
@@ -110,12 +110,10 @@ class Download::GenerateZip
     # Need to account as well for the all_submissions folder that's generated
     number_of_applications = job_submissions.pluck(:name).uniq.count + 1
 
-    number_of_entries = nil
-
-    Zip::File.open("#{@path}/#{@zip_path}") do |zip_file|
+    number_of_entries = Zip::File.open("#{@path}/#{@zip_path}") do |zip_file|
       # Subtract one because size takes into account the actual file itself
-      number_of_entries = zip_file.size - 1
-    end
+                          zip_file.size - 1
+                        end
 
     number_of_entries != number_of_applications
   end

--- a/lib/download/generate_zip.rb
+++ b/lib/download/generate_zip.rb
@@ -109,8 +109,11 @@ class Download::GenerateZip
   end
 
   def zip_contents_mismatched?(job_submissions)
+    valid_submissions = job_submissions.where.not(cv_file_name: nil, 
+      cover_letter_file_name: nil, application_form_file_name: nil)
+
     # Need to account as well for the all_submissions folder that's generated
-    number_of_applications = job_submissions.pluck(:name).uniq.count + 1
+    number_of_applications = valid_submissions.pluck(:name).map(&:downcase).uniq.count + 1
 
     number_of_entries = Zip::File.open("#{@path}/#{@zip_path}") do |zip_file|
       # Subtract one because size takes into account the actual file itself

--- a/lib/download/generate_zip.rb
+++ b/lib/download/generate_zip.rb
@@ -1,3 +1,5 @@
+require 'zip'
+
 class Download::GenerateZip
 
   def initialize path, zip_path

--- a/lib/download/generate_zip.rb
+++ b/lib/download/generate_zip.rb
@@ -112,7 +112,7 @@ class Download::GenerateZip
     return true unless File.exists?("#{@path}/#{@zip_path}")
     
     valid_submissions = job_submissions.where.not(cv_file_name: nil, 
-      cover_letter_file_name: nil, application_form_file_name: nil)
+      cover_letter_file_name: nil, application_form_file_name: nil, is_submitted: false)
 
     # Need to account as well for the all_submissions folder that's generated
     number_of_applications = valid_submissions.pluck(:name).map(&:downcase).uniq.count + 1

--- a/lib/download/generate_zip.rb
+++ b/lib/download/generate_zip.rb
@@ -121,7 +121,7 @@ class Download::GenerateZip
     # Need to account as well for the all_submissions folder that's usually generated
     number_of_entries = zip_file.glob('*/*').count
     all_applications_folder = zip_file.entries.map(&:name).find do |folder|
-                                folder.split('/').last.gsub('/', '') == 'all_submissions'
+                                folder.split('/').last == 'all_submissions'
                               end
 
     number_of_entries -= 1 if all_applications_folder

--- a/lib/download/generate_zip.rb
+++ b/lib/download/generate_zip.rb
@@ -115,10 +115,8 @@ class Download::GenerateZip
     # Need to account as well for the all_submissions folder that's generated
     number_of_applications = valid_submissions.pluck(:name).map(&:downcase).uniq.count + 1
 
-    number_of_entries = Zip::File.open("#{@path}/#{@zip_path}") do |zip_file|
-      # Subtract one because size takes into account the actual file itself
-                          zip_file.size - 1
-                        end
+    # Subtract one because size takes into account the actual file itself
+    number_of_entries = Zip::File.open("#{@path}/#{@zip_path}").glob('*/*').count - 1
 
     number_of_entries != number_of_applications
   end


### PR DESCRIPTION
**Ticket**

https://unep-wcmc.codebasehq.com/projects/bits-and-bugs/tickets/39

Added an extra condition to the `download_all_applications_zip` method in the Job Applications controller which checks whether the number of folders in the generated zip file matches the number of submissions expected, and if not, regenerates the zip. I did notice that the modified time of a few of the zip files in the cache (on production) were after the `updated_at` of the last submission without including newer applications in the zip, which was odd. Couldn't pinpoint where they were being modified, so I came to the conclusion that the zip might not be regenerating when it should, hence I thought about adding another way to check whether the zip was up to date. 