### PR TITLE
Fix/zip with personal details

### DIFF
--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -73,7 +73,7 @@ class Submission < ActiveRecord::Base
   end
 
   def attachments_valid?
-    cover_letter_file_name.present? && cv_file_name.present? && personal_details_form_file_name.present?
+    cover_letter_file_name.present? && cv_file_name.present? 
   end
 
   private

--- a/lib/download/generate_zip.rb
+++ b/lib/download/generate_zip.rb
@@ -31,14 +31,14 @@ class Download::GenerateZip
     cv_extension = File.extname(submission.cv_file_name)
     application_form_extension = submission.application_form_file_name.present? ? File.extname(submission.application_form_file_name) : nil
     cover_letter_extension = File.extname(submission.cover_letter_file_name)
-    personal_details_form_extension = File.extname(submission.personal_details_form_file_name)
+    personal_details_form_extension = submission.personal_details_form_file_name.present? ? File.extname(submission.personal_details_form_file_name) : nil
 
     begin
       custom_system("mkdir #{zipped_files_path}", @path)
       custom_system("cp \"#{submission.cv.path}\" #{document_path}_CV#{cv_extension}", @path)
       custom_system("cp \"#{submission.application_form.path}\" #{document_path}_Application#{application_form_extension}", @path) unless application_form_extension.nil?
       custom_system("cp \"#{submission.cover_letter.path}\" #{document_path}_Cover_letter#{cover_letter_extension}", @path)
-      custom_system("cp \"#{submission.personal_details_form.path}\" #{document_path}_Personal_details#{personal_details_form_extension}", @path)
+      custom_system("cp \"#{submission.personal_details_form.path}\" #{document_path}_Personal_details#{personal_details_form_extension}", @path) unless personal_details_form_extension.nil?
       add_documents_to_zip(zipped_files_path)
       custom_system("rm -rf #{zipped_files_path}", @path)
     rescue Exception => e
@@ -75,15 +75,14 @@ class Download::GenerateZip
       cv_extension = File.extname(submission.cv_file_name)
       application_form_extension = submission.application_form_file_name.present? ? File.extname(submission.application_form_file_name) : nil
       cover_letter_extension = File.extname(submission.cover_letter_file_name)
-      personal_details_form_extension = File.extname(submission.personal_details_form_file_name)
-
+      personal_details_form_extension = submission.personal_details_form_file_name.present? ? File.extname(submission.personal_details_form_file_name) : nil
       begin
         custom_system("mkdir #{zipped_files_path}/#{candidate_path}", @path) unless Dir.exists?("#{@path}/#{zipped_files_path}/#{candidate_path}")
 
         custom_system("cp \"#{submission.cv.path}\" #{documents_path}_CV#{cv_extension}", @path)
         custom_system("cp \"#{submission.application_form.path}\" #{documents_path}_Application#{application_form_extension}", @path) unless application_form_extension.nil?
         custom_system("cp \"#{submission.cover_letter.path}\" #{documents_path}_Cover_letter#{cover_letter_extension}", @path)
-        custom_system("cp \"#{submission.personal_details_form.path}\" #{document_path}_Personal_details#{personal_details_form_extension}", @path)
+        custom_system("cp \"#{submission.personal_details_form.path}\" #{document_path}_Personal_details#{personal_details_form_extension}", @path) unless personal_details_form_extension.nil?
 
         custom_system("mkdir #{zipped_files_path}/#{all_submissions_path}", @path) unless Dir.exists?("#{@path}/#{zipped_files_path}/#{all_submissions_path}")
         custom_system("cp #{zipped_files_path}/#{candidate_path}/* #{zipped_files_path}/#{all_submissions_path}", @path)
@@ -118,7 +117,7 @@ class Download::GenerateZip
     valid_submissions = job_submissions.where.not(
       cv_file_name: nil, 
       cover_letter_file_name: nil, 
-      personal_details_form_file_name: nil, 
+      # personal_details_form_file_name: nil, 
       application_form_file_name: nil, 
       is_submitted: false
     )

--- a/lib/download/generate_zip.rb
+++ b/lib/download/generate_zip.rb
@@ -76,14 +76,13 @@ class Download::GenerateZip
       application_form_extension = submission.application_form_file_name.present? ? File.extname(submission.application_form_file_name) : nil
       cover_letter_extension = File.extname(submission.cover_letter_file_name)
       personal_details_form_extension = submission.personal_details_form_file_name.present? ? File.extname(submission.personal_details_form_file_name) : nil
+
       begin
         custom_system("mkdir #{zipped_files_path}/#{candidate_path}", @path) unless Dir.exists?("#{@path}/#{zipped_files_path}/#{candidate_path}")
-
         custom_system("cp \"#{submission.cv.path}\" #{documents_path}_CV#{cv_extension}", @path)
         custom_system("cp \"#{submission.application_form.path}\" #{documents_path}_Application#{application_form_extension}", @path) unless application_form_extension.nil?
         custom_system("cp \"#{submission.cover_letter.path}\" #{documents_path}_Cover_letter#{cover_letter_extension}", @path)
-        custom_system("cp \"#{submission.personal_details_form.path}\" #{document_path}_Personal_details#{personal_details_form_extension}", @path) unless personal_details_form_extension.nil?
-
+        custom_system("cp \"#{submission.personal_details_form.path}\" #{documents_path}_Personal_details#{personal_details_form_extension}", @path) unless personal_details_form_extension.nil?
         custom_system("mkdir #{zipped_files_path}/#{all_submissions_path}", @path) unless Dir.exists?("#{@path}/#{zipped_files_path}/#{all_submissions_path}")
         custom_system("cp #{zipped_files_path}/#{candidate_path}/* #{zipped_files_path}/#{all_submissions_path}", @path)
       rescue Exception => e
@@ -113,11 +112,13 @@ class Download::GenerateZip
 
   def zip_contents_mismatched?(job_submissions)
     return true unless File.exists?("#{@path}/#{@zip_path}")
-    
+
+    # NB: This isn't taking into account personal details forms, because there are
+    # still submissions for jobs (at the time of commenting) that don't have personal 
+    # details forms attached, and thus wouldn't be 'valid' submissions according to the below
     valid_submissions = job_submissions.where.not(
       cv_file_name: nil, 
       cover_letter_file_name: nil, 
-      # personal_details_form_file_name: nil, 
       application_form_file_name: nil, 
       is_submitted: false
     )


### PR DESCRIPTION
Fixes submissions without personal details forms not downloading, as well as the all submissions folder not featuring those older submissions when the combined zip is downloaded. 